### PR TITLE
Fix: alternate sites for site sync

### DIFF
--- a/client/ayon_sitesync/sync_server.py
+++ b/client/ayon_sitesync/sync_server.py
@@ -78,11 +78,6 @@ async def upload(module, project_name, file, representation, provider_name,
                                          True
                                          )
 
-    module.handle_alternate_site(project_name,
-                                 representation["representationId"],
-                                 remote_site_name,
-                                 file["fileHash"])
-
     return file_id
 
 
@@ -134,11 +129,6 @@ async def download(module, project_name, file, representation, provider_name,
                                          local_site,
                                          True
                                          )
-
-    module.handle_alternate_site(project_name,
-                                 representation["representationId"],
-                                 local_site,
-                                 file["fileHash"])
 
     return file_id
 
@@ -456,6 +446,12 @@ class SyncServerThread(threading.Thread):
                                               site_name=site_name,
                                               side=side,
                                               error=error)
+
+                        repre_id = representation["representationId"]
+                        self.module.handle_alternate_site(project_name,
+                                                          repre_id,
+                                                          site_name,
+                                                          file["fileHash"])
 
                 duration = time.time() - start_time
                 self.log.debug("One loop took {:.2f}s".format(duration))

--- a/client/ayon_sitesync/sync_server_module.py
+++ b/client/ayon_sitesync/sync_server_module.py
@@ -887,6 +887,10 @@ class SyncServerModule(AYONAddon, ITrayModule, IPluginPaths):
                                                processed_site)
         if not sync_state:
             raise RuntimeError("Cannot find repre with '{}".format(representation_id))  # noqa
+        for file_info in sync_state["files"]:
+            #expose status of remote site, it is expected on the server
+            file_info["status"] = file_info["remoteStatus"]["status"]
+
         payload_dict = {"files": sync_state["files"]}
 
         alternate_sites = set(alternate_sites)
@@ -894,7 +898,7 @@ class SyncServerModule(AYONAddon, ITrayModule, IPluginPaths):
             self.log.debug("Adding alternate {} to {}".format(
                 alt_site, representation_id))
             self._set_state_sync_state(project_name, representation_id,
-                                       site_name,
+                                       alt_site,
                                        payload_dict)
 
     # TODO - for Loaders
@@ -1139,6 +1143,9 @@ class SyncServerModule(AYONAddon, ITrayModule, IPluginPaths):
                 configured_site = {}
                 site_name = whole_site_info["name"]
                 configured_site["enabled"] = True
+                configured_site["alternative_sites"] = (
+                    whole_site_info["alternative_sites"]
+                )
 
                 provider_specific = whole_site_info[whole_site_info["provider"]]
                 configured_site["root"] = provider_specific.pop("roots",


### PR DESCRIPTION
Status of remote site must be set directly on file dictionary.
Setting of alternate status must be later, it was preceding setting of state of processed site.