### PR TITLE
Fix status overwriting in update_db

### DIFF
--- a/client/ayon_sitesync/sync_server_module.py
+++ b/client/ayon_sitesync/sync_server_module.py
@@ -1358,7 +1358,7 @@ class SyncServerModule(AYONAddon, ITrayModule, IPluginPaths):
                         status_doc["pause"] = True
                     else:
                         status_doc.remove("pause")
-            files_status.append(status_doc)
+                files_status.append(status_doc)
 
         representation_id = representation["representationId"]
 


### PR DESCRIPTION
Currently update_db() updates all files from the representation per file-processing. This resets the sync-statuses of all files to QUEUED except the file that's being processed.

This PR fixes this my making sure `files_status.append(status_doc)` only happens for the current file that's being processed.

To try the fix, set SiteSync active to local and remote to studio. Publish a render and let it sync to studio.