### PR TITLE
Chore: Use AYON environment variable

### DIFF
--- a/client/ayon_sitesync/addon.py
+++ b/client/ayon_sitesync/addon.py
@@ -796,7 +796,7 @@ class SiteSyncAddon(AYONAddon, ITrayAddon, IPluginPaths):
 
     def _reset_timer_with_rest_api(self):
         # POST to webserver sites to add to representations
-        webserver_url = os.environ.get("OPENPYPE_WEBSERVER_URL")
+        webserver_url = os.environ.get("AYON_WEBSERVER_URL")
         if not webserver_url:
             self.log.warning("Couldn't find webserver url")
             return


### PR DESCRIPTION
## Description
SiteSync seems to be still using deprecated environment variable `OPENPYPE_WEBSERVER_URL` that will be removed soon from ayon-core.