### PR TITLE
Fix: site studio already present

### DIFF
--- a/client/ayon_sitesync/addon.py
+++ b/client/ayon_sitesync/addon.py
@@ -338,11 +338,14 @@ class SiteSyncAddon(AYONAddon, ITrayAddon, IPluginPaths):
         # add skeleton for sites where it should be always synced to
         # usually it would be a backup site which is handled by separate
         # background process
-        for site in self._get_always_accessible_sites(project_name):
-            if site not in attached_sites:
-                attached_sites[site] = create_metadata(site, created=False)
-
-        return list(attached_sites.values())
+        for site_name in self._get_always_accessible_sites(project_name):
+            if site_name not in attached_sites:
+                attached_sites[site_name] = (
+                    create_metadata(site_name, created=False))
+        unique_sites = {}
+        for site in attached_sites.values():
+            unique_sites[site["name"]] = site
+        return list(unique_sites.values())
 
     def _get_always_accessible_sites(self, project_name):
         """Sites that synced to as a part of background process.

--- a/client/ayon_sitesync/addon.py
+++ b/client/ayon_sitesync/addon.py
@@ -353,12 +353,15 @@ class SiteSyncAddon(AYONAddon, ITrayAddon, IPluginPaths):
         Artist machine doesn't handle those, explicit Tray with that site name
         as a local id must be running.
         Example is dropbox site serving as a backup solution
+
+        Returns:
+            (list[str]): list of site names
         """
         sync_settings = self.get_sync_project_setting(project_name)
         always_accessible_sites = (
             sync_settings["config"].get("always_accessible_on", [])
         )
-        return [site.strip() for site in always_accessible_sites]
+        return [site_name.strip() for site_name in always_accessible_sites]
 
     def _add_alternative_sites(self, project_name, attached_sites):
         """Add skeleton document for alternative sites
@@ -368,6 +371,9 @@ class SiteSyncAddon(AYONAddon, ITrayAddon, IPluginPaths):
         physically accessible also on 'a alternative' site.
         Example is sftp site serving studio files via sftp protocol, physically
         file is only in studio, sftp server has this location mounted.
+
+        Returns:
+            (dict[str, dict])
         """
         sync_project_settings = self.get_sync_project_setting(project_name)
         all_sites = sync_project_settings["sites"]

--- a/client/ayon_sitesync/addon.py
+++ b/client/ayon_sitesync/addon.py
@@ -342,9 +342,10 @@ class SiteSyncAddon(AYONAddon, ITrayAddon, IPluginPaths):
             if site_name not in attached_sites:
                 attached_sites[site_name] = (
                     create_metadata(site_name, created=False))
-        unique_sites = {}
-        for site in attached_sites.values():
-            unique_sites[site["name"]] = site
+        unique_sites = {
+            site["name"]: site
+            for site in attached_sites.values()
+        }
         return list(unique_sites.values())
 
     def _get_always_accessible_sites(self, project_name):

--- a/client/ayon_sitesync/plugins/publish/integrate_site_sync.py
+++ b/client/ayon_sitesync/plugins/publish/integrate_site_sync.py
@@ -28,12 +28,14 @@ class IntegrateSiteSync(pyblish.api.InstancePlugin):
         if sitesync_addon is None:
             return
 
-        for repre_id, inst in published_representations.items():  # noqa
-            sites = sitesync_addon.compute_resource_sync_sites(
-                project_name=project_name
-            )
-
+        sites = sitesync_addon.compute_resource_sync_sites(
+            project_name=project_name
+        )
+        for repre_id, inst in published_representations.items():
             for site_info in sites:
-                sitesync_addon.add_site(project_name, repre_id,
-                                        site_info["name"],
-                                        status=site_info["status"])
+                sitesync_addon.add_site(
+                    project_name,
+                    repre_id,
+                    site_info["name"],
+                    status=site_info["status"]
+                )


### PR DESCRIPTION
## Changelog Description
Added protection from duplicate sites.

## Additional review information
Multiple clients reported issue in `integrate_site_sync` with `Site already present`, couldnt reproduce on our side, but this protection shouldn't hurt

### Error
```
"/ayon/addons/sitesync_1.2.0/ayon_sitesync/addon.py", line 220, in add_site 
    raise SiteAlreadyPresentError(msg) 
ayon_sitesync.utils.SiteAlreadyPresentError: Site studio already present 
!!! ERR: 
{ CLI-publish }: [ Failed IntegrateSiteSync: Site studio already present -- ('/ayon/addons/sitesync_1.2.0/ayon_sitesync/plugins/publish/integrate_site_sync.py', 220, 'add_site', 'raise SiteAlreadyPresentError(msg)') ]
```
Issue linked https://app.clickup.com/t/6658547/AY-7096
Should close https://github.com/ynput/ayon-sitesync/issues/42

## Testing notes:
1. publish something with SiteSync enabled
