### PR TITLE
Fix: failure with too many open files

### DIFF
--- a/client/ayon_sitesync/sitesync.py
+++ b/client/ayon_sitesync/sitesync.py
@@ -548,7 +548,8 @@ class SiteSyncThread(threading.Thread):
                     remote_site,
                     preset.get("config")
                 )
-                if status == SyncStatus.DO_UPLOAD:
+                if (status == SyncStatus.DO_UPLOAD and
+                        len(task_files_to_process) < limit):
                     tree = handler.get_tree()
                     task = asyncio.create_task(
                         upload(
@@ -573,7 +574,8 @@ class SiteSyncThread(threading.Thread):
                     ))
                     processed_file_path.add(file_path)
 
-                if status == SyncStatus.DO_DOWNLOAD:
+                if (status == SyncStatus.DO_DOWNLOAD and
+                        len(task_files_to_process) < limit):
                     tree = handler.get_tree()
                     task = asyncio.create_task(
                         download(

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -533,7 +533,7 @@ def get_overal_status(files: dict) -> StatusEnum:
         return StatusEnum.IN_PROGRESS
     elif any(stat == StatusEnum.PAUSED for stat in all_states):
         return StatusEnum.PAUSED
-    elif all(stat == StatusEnum.QUEUED for stat in all_states):
+    elif any(stat == StatusEnum.QUEUED for stat in all_states):
         return StatusEnum.QUEUED
     return StatusEnum.NOT_AVAILABLE
 


### PR DESCRIPTION
## Changelog Description
Limitation of how many files should be processed were not applied correctly resulting in possible issue with large frame sequences.

## Additional review information
Tested successfully on client's system.
