### PR TITLE
Fix: limit failed from requerying

### DIFF
--- a/client/ayon_sitesync/addon.py
+++ b/client/ayon_sitesync/addon.py
@@ -1500,11 +1500,18 @@ class SiteSyncAddon(AYONAddon, ITrayAddon, IPluginPaths):
                     status_entity["status"] = SiteSyncStatus.IN_PROGRESS
                     status_entity["progress"] = progress
                 elif error:
-
+                    max_retries = int(
+                        self.sync_project_settings
+                        [project_name]
+                        ["config"]
+                        ["retry_cnt"]
+                    )
                     tries = status_entity.get("retries", 0)
                     tries += 1
                     status_entity["retries"] = tries
                     status_entity["message"] = error
+                    if tries >= max_retries:
+                        status_entity["status"] = SiteSyncStatus.FAILED
                 elif pause is not None:
                     if pause:
                         status_entity["pause"] = True

--- a/client/ayon_sitesync/addon.py
+++ b/client/ayon_sitesync/addon.py
@@ -1373,9 +1373,7 @@ class SiteSyncAddon(AYONAddon, ITrayAddon, IPluginPaths):
             "localSite": active_site,
             "remoteSite": remote_site,
             "localStatusFilter": [SiteSyncStatus.OK],
-            "remoteStatusFilter": [
-                SiteSyncStatus.QUEUED, SiteSyncStatus.FAILED
-            ]
+            "remoteStatusFilter": [SiteSyncStatus.QUEUED],
         }
 
         response = ayon_api.get(endpoint, **kwargs)
@@ -1390,9 +1388,7 @@ class SiteSyncAddon(AYONAddon, ITrayAddon, IPluginPaths):
 
         # get to download
         if len(repre_states) < limit:
-            kwargs["localStatusFilter"] = [
-                SiteSyncStatus.QUEUED, SiteSyncStatus.FAILED
-            ]
+            kwargs["localStatusFilter"] = [SiteSyncStatus.QUEUED]
             kwargs["remoteStatusFilter"] = [SiteSyncStatus.OK]
 
             response = ayon_api.get(endpoint, **kwargs)
@@ -1504,7 +1500,7 @@ class SiteSyncAddon(AYONAddon, ITrayAddon, IPluginPaths):
                     status_entity["status"] = SiteSyncStatus.IN_PROGRESS
                     status_entity["progress"] = progress
                 elif error:
-                    status_entity["status"] = SiteSyncStatus.FAILED
+
                     tries = status_entity.get("retries", 0)
                     tries += 1
                     status_entity["retries"] = tries

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -239,19 +239,10 @@ class SiteSync(BaseServerAddon):
         if localStatusFilter:
             statusFilter = [str(s.value) for s in localStatusFilter]
             conditions.append(f"local.status IN ({','.join(statusFilter)})")
-        else:
-            # ignore failed sites, would block processing,
-            # need to be reset explicitly first
-            # is null check necessary to download only remote files!
-            conditions.append(f"(local.status IS NULL OR "
-                              f"local.status != {StatusEnum.FAILED})")
 
         if remoteStatusFilter:
             statusFilter = [str(s.value) for s in remoteStatusFilter]
             conditions.append(f"remote.status IN ({','.join(statusFilter)})")
-        else:
-            conditions.append(f"(remote.status IS NULL OR "
-                              f"remote.status != {StatusEnum.FAILED} )")
 
         if repreNameFilter:
             conditions.append(f"r.name IN {SQLTool.array(repreNameFilter)}")

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -299,7 +299,6 @@ class SiteSync(BaseServerAddon):
             LIMIT {pageLength}
             OFFSET { (page-1) * pageLength }
         """
-        print(f"query::{query}")
         repres = []
 
         async for row in Postgres.iterate(query):


### PR DESCRIPTION
## Changelog Description
Updated logic of failed representations. Previously failure set repre as Failed, repres for synchronization were queried as `Queued` OR `Failed`. This resulted in filling up stack of repres to be synchronized with failed ones if too many repres were failed and unresolved.

Now if failure happens, repre is still in `Queued` state and set to `Failed` only after limit of retries is hit.

## Additional review information
This will be difficult to test as one needs to have large amount of failed representation. I think it could be tried with SFTP the simplest.

## Testing notes:
1. Create site with working SFTP
2. start Tray
3. change password or anything in SFTP configuration  to trigger failure when uploading (must be done only after Tray start)
4. upload at least 20 representations (via Publisher would be easiest, you just drag & drop once and run Publish multiple times)
5. change sftp configuration back to working 
6. upload new representation - these should be synchronized (without this PR they would stay stucked in `Queued`)
