### PR TITLE
Correct GDRIVE down/up size limit of 100MB

### DIFF
--- a/client/ayon_sitesync/providers/gdrive.py
+++ b/client/ayon_sitesync/providers/gdrive.py
@@ -266,9 +266,10 @@ class GDriveHandler(AbstractProvider):
 
             media.stream()
             self.log.debug("Start Upload! {}".format(source_path))
-            last_tick = status = response = None
+            last_tick = status = None
+            response = False
             status_val = 0
-            while response is None:
+            while response is False:
                 if addon.is_representation_paused(
                         repre_status["representationId"],
                         check_parents=True,
@@ -362,9 +363,10 @@ class GDriveHandler(AbstractProvider):
 
         with open(local_path + "/" + target_name, "wb") as fh:
             downloader = MediaIoBaseDownload(fh, request)
-            last_tick = status = response = None
+            last_tick = status = None
+            response = False
             status_val = 0
-            while response is None:
+            while response is False:
                 if addon.is_representation_paused(
                     repre_status["representationId"],
                     check_parents=True,


### PR DESCRIPTION
## Changelog Description
There is a error in the loop of the download and upload functions that prevent the loop to run more than once breaking files bigger than the default chunk size of 1024*1024

## Additional review information
The error happens in the "response" variable (file gdrive.py) that expects a return of True/False in the loop but its pre-declared as 'None'. Both upload and download functions have this behavior.


