### PR TITLE
Settings: Use 'conditional_enum'

### DIFF
--- a/server/settings/settings.py
+++ b/server/settings/settings.py
@@ -115,7 +115,7 @@ class SitesSubmodel(BaseSettingsModel):
         title="Provider",
         description="Switch between providers",
         enum_resolver=lambda: provider_enum,
-        conditionalEnum=True
+        conditional_enum=True
     )
 
     local_drive: LocalDriveSubmodel = Field(


### PR DESCRIPTION
## Changelog Description
Use `conditional_enum` instead of `conditionalEnum`.

## Testing notes:
1. Settings still do work.
