### PR TITLE
Added synchronization of hero representations

### DIFF
--- a/client/ayon_sitesync/addon.py
+++ b/client/ayon_sitesync/addon.py
@@ -1776,6 +1776,42 @@ class SiteSyncAddon(AYONAddon, ITrayAddon, IPluginPaths):
             if repre_state["localStatus"]["status"] != -1:
                 return repre_state
 
+    def get_representations_sites_sync_state(
+        self,
+        project_name,
+        representation_ids,
+        site_names = None
+    ):
+        """ Returns all site states for representation ids.
+
+        Args:
+            project_name (str):
+            representation_ids (list[str]): even single repre should be in []
+            site_names (list[str]): sub-selection of states
+
+        Returns:
+            list[dict]: dicts follow RepresentationSiteStateModel
+        """
+        endpoint = "{}/{}/state/representations".format(
+            self.endpoint_prefix, project_name
+        )
+
+        payload_dict = {
+            "representationIds": representation_ids
+        }
+        if site_names:
+            payload_dict["siteNames"] = site_names
+
+        response = ayon_api.get(endpoint, **payload_dict)
+        if response.status_code != 200:
+            raise RuntimeError(
+                "Can't get all sites sync state for representations {}".format(
+                    representation_ids
+                )
+            )
+
+        return response.data
+
     def get_representations_sync_state(
         self,
         project_name,

--- a/client/ayon_sitesync/addon.py
+++ b/client/ayon_sitesync/addon.py
@@ -1780,7 +1780,7 @@ class SiteSyncAddon(AYONAddon, ITrayAddon, IPluginPaths):
         self,
         project_name,
         representation_ids,
-        site_names = None
+        site_names=None,
     ):
         """ Returns all site states for representation ids.
 

--- a/client/ayon_sitesync/addon.py
+++ b/client/ayon_sitesync/addon.py
@@ -234,7 +234,7 @@ class SiteSyncAddon(AYONAddon, ITrayAddon, IPluginPaths):
         representation_id = representation_id.replace("-", "")
 
         self._set_state_sync_state(
-            project_name, representation_id, site_name, payload_dict
+            project_name, representation_id, site_name, payload_dict, force
         )
 
     def remove_site(
@@ -1724,15 +1724,19 @@ class SiteSyncAddon(AYONAddon, ITrayAddon, IPluginPaths):
         return self._get_progress_for_repre_new(*args, **kwargs)
 
     def _set_state_sync_state(
-        self, project_name, representation_id, site_name, payload_dict
+        self,
+        project_name,
+        representation_id,
+        site_name,
+        payload_dict,
+        force=False,
     ):
         """Calls server endpoint to store sync info for 'representation_id'."""
         endpoint = "{}/{}/state/{}/{}".format(
-            self.endpoint_prefix,
-            project_name,
-            representation_id,
-            site_name
+            self.endpoint_prefix, project_name, representation_id, site_name
         )
+        if force:
+            endpoint = f"{endpoint}?reset=true"
 
         response = ayon_api.post(endpoint, **payload_dict)
         if response.status_code not in [200, 204]:

--- a/client/ayon_sitesync/plugins/publish/integrate_site_sync.py
+++ b/client/ayon_sitesync/plugins/publish/integrate_site_sync.py
@@ -7,6 +7,11 @@ be synchronized.
 """
 import pyblish.api
 
+from ayon_core.addon import AYONAddon
+from ayon_api import get_representations
+
+from ayon_sitesync.utils import SiteSyncStatus
+
 
 class IntegrateSiteSync(pyblish.api.InstancePlugin):
     """Adds state of published representations for syncing."""
@@ -28,14 +33,59 @@ class IntegrateSiteSync(pyblish.api.InstancePlugin):
         if sitesync_addon is None:
             return
 
-        sites = sitesync_addon.compute_resource_sync_sites(
+        published_sites = sitesync_addon.compute_resource_sync_sites(
             project_name=project_name
         )
         for repre_id, inst in published_representations.items():
-            for site_info in sites:
+            for site_info in published_sites:
                 sitesync_addon.add_site(
                     project_name,
                     repre_id,
                     site_info["name"],
                     status=site_info["status"]
                 )
+
+        hero_version_entity = instance.data.get("heroVersionEntity")
+        if not hero_version_entity:
+            return
+
+        self._reset_hero_representations(
+            project_name,
+            sitesync_addon,
+            hero_version_entity,
+            published_sites
+        )
+
+    def _reset_hero_representations(
+        self,
+        project_name: str,
+        sitesync_addon: AYONAddon,
+        hero_version_entity,
+        sites: list[dict]
+    ) -> None:
+        """Hero representations must be refreshed for all sites
+
+        Re sync of all downloaded hero version is necessary to update locally
+        cached instances.
+        """
+        hero_repres = get_representations(
+            project_name,
+            version_ids=[hero_version_entity["id"]]
+        )
+        hero_repre_ids = [repre["id"] for repre in hero_repres]
+        repres_sites = sitesync_addon.get_representations_sites_sync_state(
+            project_name, hero_repre_ids
+        )
+        publish_site_status = {site["name"]: site["status"] for site in sites}
+        for repre_on_site in repres_sites:
+            site_status = (
+                    publish_site_status.get(repre_on_site["siteName"])
+                    or SiteSyncStatus.QUEUED
+            )
+            sitesync_addon.add_site(
+                project_name,
+                repre_on_site["representationId"],
+                site_status,
+                status=site_status,
+                force=True,
+            )

--- a/client/ayon_sitesync/plugins/publish/integrate_site_sync.py
+++ b/client/ayon_sitesync/plugins/publish/integrate_site_sync.py
@@ -85,7 +85,7 @@ class IntegrateSiteSync(pyblish.api.InstancePlugin):
             sitesync_addon.add_site(
                 project_name,
                 repre_on_site["representationId"],
-                site_status,
+                repre_on_site["siteName"],
                 status=site_status,
                 force=True,
             )

--- a/server/settings/models.py
+++ b/server/settings/models.py
@@ -90,3 +90,10 @@ class RepresentationStateModel(OPModel):
 class UserSyncSites(OPModel):
     localSite: str = Field(...)
     remoteSite: str = Field(...)
+
+
+class RepresentationSiteStateModel(OPModel):
+    """High level model to get all sites status on representations"""
+    representationId: str = Field(...)
+    siteName: str = Field(...)
+    status: StatusEnum = Field(StatusEnum.NOT_AVAILABLE)


### PR DESCRIPTION
## Changelog Description
Hero representations weren't synched.

They must be reset each publish as they need to be re-downloaded to all sites where they were synced before.


## Testing notes:
1.setup SiteSync
2. enable Hero versions and publish something (model is easiest) - `ayon+settings://core/publish/IntegrateHeroVersion`
3, check that even hero version gets synced (in `hero` subfolder)
4. republish, check if new version get synced and files in `hero` folder are updated
