### PR TITLE
Replacing pysftp with sftpretty (maintained fork of pysftp)

### DIFF
--- a/client/ayon_sitesync/providers/sftp.py
+++ b/client/ayon_sitesync/providers/sftp.py
@@ -9,8 +9,15 @@ from .abstract_provider import AbstractProvider
 
 log = Logger.get_logger("SiteSync-SFTPHandler")
 
-import sftpretty
-import paramiko
+sftpretty = None
+try:
+    import sftpretty
+    import paramiko
+except (ImportError, SyntaxError):
+    pass
+
+    # handle imports from Python 2 hosts - in those only basic methods are used
+    log.warning("Import failed, imported from Python 2, operations will fail.")
 
 
 class SFTPHandler(AbstractProvider):
@@ -295,6 +302,9 @@ class SFTPHandler(AbstractProvider):
         Returns:
             sftpretty.Connection
         """
+        if not sftpretty:
+            raise ImportError
+
         cnopts = sftpretty.CnOpts()
         cnopts.log_level = "error"
         cnopts.hostkeys = None

--- a/client/ayon_sitesync/providers/sftp.py
+++ b/client/ayon_sitesync/providers/sftp.py
@@ -303,7 +303,10 @@ class SFTPHandler(AbstractProvider):
             sftpretty.Connection
         """
         if not sftpretty:
-            raise ImportError
+            raise ImportError(
+                "Library for SFTP provider is not available, "
+                "ask admin to update dependency package."
+            )
 
         cnopts = sftpretty.CnOpts()
         cnopts.log_level = "error"

--- a/client/ayon_sitesync/providers/sftp.py
+++ b/client/ayon_sitesync/providers/sftp.py
@@ -112,7 +112,7 @@ class SFTPHandler(AbstractProvider):
         Returns:
             (string) folder id of lowest subfolder from 'path'
         """
-        self.conn.makedirs(path)
+        self.conn.mkdir_p(path)
 
         return os.path.basename(path)
 

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -1,4 +1,4 @@
 [ayon.runtimeDependencies]
-pysftp = "^0.2.9"
+sftpretty = "^1.2.0"
 dropbox = "^11.20.0"
 google-api-python-client = "^1.12.8"


### PR DESCRIPTION
## Changelog Description
- Resolves `ImportERROR` on SiteSync start when using SFTP provider.
- Removes dependency: [pysftp](https://bitbucket.org/dundeemt/pysftp)
- Adds dependency: [sftpretty](https://github.com/byteskeptical/sftpretty)

resolve #17 

## Additional review information
[pysftp](https://bitbucket.org/dundeemt/pysftp) throws and error when imported, as it imports features from [paramiko](https://github.com/paramiko/paramiko) that has been removed due to deprecation. [pysftp](https://bitbucket.org/dundeemt/pysftp) is an unmaintained library. This PR replaces pysftp with [sftpretty](https://github.com/byteskeptical/sftpretty) which is a maintained fork of [pysftp](https://bitbucket.org/dundeemt/pysftp).

## Testing notes:
1. Update package
2. Update dependency
3. Add site with SFTP provider to ayon+settings://sitesync
4. Launch Ayon launcher, no `ImportERROR` should appear
5. Download & Upload via SiteSync SFTP Provider
