### PR TITLE
Chore: Use product base types

### DIFF
--- a/client/ayon_sitesync/launch_hooks/pre_copy_last_published_workfile.py
+++ b/client/ayon_sitesync/launch_hooks/pre_copy_last_published_workfile.py
@@ -192,6 +192,7 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
             folder_ids={folder_id},
             product_base_types={"workfile"},
         )
+        # TODO add requirement for AYON launcher 1.4.3 when removed
         if not is_func_signature_supported(
             get_products, project_name, **kwargs
         ):

--- a/client/ayon_sitesync/launch_hooks/pre_copy_last_published_workfile.py
+++ b/client/ayon_sitesync/launch_hooks/pre_copy_last_published_workfile.py
@@ -7,6 +7,7 @@ from ayon_api import (
     get_last_versions
 )
 
+from ayon_core.lib import is_func_signature_supported
 from ayon_core.pipeline.template_data import get_template_data
 from ayon_core.pipeline.workfile import get_workfile_template_key
 from ayon_core.pipeline.workfile import should_use_last_workfile_on_launch
@@ -187,11 +188,17 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
     ):
         """Looks for last published representation for host and context"""
 
-        product_entities = get_products(
-            project_name,
+        kwargs = dict(
             folder_ids={folder_id},
-            product_types={"workfile"}
+            product_base_types={"workfile"},
         )
+        if not is_func_signature_supported(
+            get_products, project_name, **kwargs
+        ):
+            kwargs["product_types"] = kwargs.pop("product_base_types")
+
+        product_entities = get_products(project_name, **kwargs)
+
         product_ids = {
             product_entity["id"]
             for product_entity in product_entities

--- a/package.py
+++ b/package.py
@@ -5,6 +5,7 @@ title = "SiteSync"
 version = "1.2.5+dev"
 client_dir = "ayon_sitesync"
 
+ayon_launcher_version = ">=1.4.3"
 ayon_required_addons = {
     "core": ">=0.3.0",
 }


### PR DESCRIPTION
## Changelog Description
Use product base types to fetch products.

## Notes
The kwarg was added in ayon_api 1.2.5 but actually works since ayon_api 1.2.6 which is available since AYON launcher 1.4.3.

## Testing notes:
1. Affected functionality still works (I don't know what it does).
