### PR TITLE
bugfix/sftpretty-knownhosts

### DIFF
--- a/client/ayon_sitesync/providers/sftp.py
+++ b/client/ayon_sitesync/providers/sftp.py
@@ -310,7 +310,6 @@ class SFTPHandler(AbstractProvider):
 
         cnopts = sftpretty.CnOpts(knownhosts=None)
         cnopts.log_level = "error"
-        cnopts.hostkeys = None
 
         conn_params = {
             "host": self.sftp_host,
@@ -333,6 +332,7 @@ class SFTPHandler(AbstractProvider):
                 raise ValueError(
                     f"Certificate at '{key_paths}' doesn't exist."
                 )
+                
         if self.sftp_key_pass:
             conn_params["private_key_pass"] = self.sftp_key_pass
 
@@ -357,6 +357,7 @@ class SFTPHandler(AbstractProvider):
     ):
         """
             Updates progress field in DB by values 0-1.
+            
 
             Compares file sizes of source and target.
         """

--- a/client/ayon_sitesync/providers/sftp.py
+++ b/client/ayon_sitesync/providers/sftp.py
@@ -308,7 +308,7 @@ class SFTPHandler(AbstractProvider):
                 "ask admin to update dependency package."
             )
 
-        cnopts = sftpretty.CnOpts()
+        cnopts = sftpretty.CnOpts(knownhosts=None)
         cnopts.log_level = "error"
         cnopts.hostkeys = None
 


### PR DESCRIPTION
## Changelog Description
Fixing an issue with ignoring a missing `%USERPROFILE%\.ssh\known_hosts` file on Windows introduced with the switch from pysftp to sftpretty. Solves issue #74

## Additional review information
Removing the former `cnopts.hostkeys = None` line that worked in pysftp and adding the `knownhosts=None` argument to the `sftpretty.CnOpts()` function call as sftpretty expects. This is not advised since it allows for man in the middle attacks, but it is in-line with past behavior.
Relevant documentation: https://docs.sftpretty.com/cookbook.html#sftpretty-cnopts

## Testing notes:
1. Rename `%USERPROFILE%\.ssh\known-hosts` file if it exists
2. Run current 1.2.6 develop branch
