### PR TITLE
Launch hook: Handle 'workfile_path'

### DIFF
--- a/client/ayon_sitesync/launch_hooks/pre_copy_last_published_workfile.py
+++ b/client/ayon_sitesync/launch_hooks/pre_copy_last_published_workfile.py
@@ -44,6 +44,11 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
         Returns:
             None: This is a void method.
         """
+        workfile_path = self.data.get("workfile_path")
+        if workfile_path:
+            self.log.debug("Explicit workfile path to open is defined.")
+            return
+
         project_name = self.data["project_name"]
         sitesync_addon = self.addons_manager.get("sitesync")
         if (


### PR DESCRIPTION
## Changelog Description
Handle `"workfile_path"` in launch hook.

## Additional review information
The key is used for explicit workfile path to run. The setter of the key makes sure the workfile path exists (e.g. launcher tool when opening workfile from workfile entity). In that case the logic of launch hook can be skipped.
