### PR TITLE
Fix: update dropbox dependency version to 12.0.0

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -1,4 +1,4 @@
 [ayon.runtimeDependencies]
 sftpretty = "^1.2.0"
-dropbox = "^11.20.0"
+dropbox = "^12.0.0"
 google-api-python-client = "^1.12.8"


### PR DESCRIPTION
## Changelog Description
Bumping dependency as the old one was breaking on new `setuptools` thanks to the missing `pkg_resources`.

## Additional review information
`pkg_resources` are depracated and removed in Python 3.12 anyway. The solution would be to either pin setuptools < 82 or bumping the version of dropbox.

Closes #84

> [!NOTE]
> You need to build new dependency package to test this.

## Testing notes:
* SiteSync with dropbox should work as usual
* You shouldn't see any error related to `pkg_config` when running AYON with SiteSync
